### PR TITLE
fix: Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM rust:latest as builder
 WORKDIR /app
 COPY . .
-CMD ["cargo", "build", "--release"]
+RUN cargo build --release
 
-FROM rust:latest
+FROM ubuntu:latest
 WORKDIR /app
-COPY --from=builder /app /app
-CMD ["cargo","run","--release"]
+COPY --from=builder /app/target/release/spell-check-api .
+CMD ["./spell-check-api"]


### PR DESCRIPTION
This PR fixes the dockerfile in 2 ways

1: use RUN instead of CMD, since CMD marks the command needed to run the image instead of a command that should be run while building - [see](https://betterstack.com/community/questions/difference-between-run-and-cmd-in-dockerfile/)

2: only copy the executable so cargo is not needed to run the image 